### PR TITLE
redirect_uri is optional for WebServer Client

### DIFF
--- a/lib/OIDC/Lite/Client/WebServer.pm
+++ b/lib/OIDC/Lite/Client/WebServer.pm
@@ -240,7 +240,7 @@ sub get_access_token {
 
     my %args = Params::Validate::validate(@_, {
         code         => 1,
-        redirect_uri => 1,
+        redirect_uri => { optional => 1 },
         server_state => { optional => 1 },
         uri          => { optional => 1 },
         use_basic_schema    => { optional => 1 },
@@ -254,8 +254,8 @@ sub get_access_token {
     my %params = (
         grant_type    => 'authorization_code',
         code          => $args{code},
-        redirect_uri  => $args{redirect_uri},
     );
+    $params{redirect_uri} = $args{redirect_uri} if $args{redirect_uri};
     $params{server_state} = $args{server_state} if $args{server_state};
 
     unless ($args{use_basic_schema}){

--- a/t/040_unit/client/web_server.t
+++ b/t/040_unit/client/web_server.t
@@ -252,4 +252,12 @@ is($res->id_token, q{id_token_1});
 is($res->expires_in, q{3600});
 is($res->scope, q{email});
 
+# redirect_uri is optional for get_access_token
+eval {
+    $res = $client->get_access_token(
+        code         => q{invalid},
+    );
+};
+ok(!$@, qr/redirect_uri is optional/);
+
 done_testing;


### PR DESCRIPTION
In specifications of OAuth2.0(RFC6749), access token request requires redirect_uri param.
However, Google supports a request which doesn't include it.
https://developers.google.com/accounts/docs/CrossClientAuth?hl=en
"Android app obtains offline access for web back-end"
