### PR TITLE
Fix load error on OIDC::Lite::Server::GrantHandlers 

### DIFF
--- a/lib/OIDC/Lite/Server/GrantHandlers.pm
+++ b/lib/OIDC/Lite/Server/GrantHandlers.pm
@@ -8,6 +8,7 @@ use OAuth::Lite2::Server::GrantHandler::RefreshToken;
 use OAuth::Lite2::Server::GrantHandler::ClientCredentials;
 use OAuth::Lite2::Server::GrantHandler::GroupingRefreshToken;
 use OAuth::Lite2::Server::GrantHandler::ServerState;
+use OAuth::Lite2::Server::GrantHandler::ExternalService;
 
 my %HANDLERS;
 

--- a/t/040_unit/server/grant_handlers.t
+++ b/t/040_unit/server/grant_handlers.t
@@ -1,0 +1,8 @@
+use strict;
+use Test::More;
+
+BEGIN {
+    use_ok('OIDC::Lite::Server::GrantHandlers');
+};
+
+done_testing;


### PR DESCRIPTION
I tried to use `OIDC::Lite::Server::GrantHandlers`, then I got this error.
```
Error:  Can't locate object method "new" via package "OAuth::Lite2::Server::GrantHandler::ExternalService" (perhaps you forgot to load "OAuth::Lite2::Server::GrantHandler::ExternalService"?)
```