### PR TITLE
Remove unused dependencies

### DIFF
--- a/META.json
+++ b/META.json
@@ -28,9 +28,7 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Crypt::OpenSSL::RSA" : "0",
             "ExtUtils::MakeMaker" : "6.62",
-            "Test::Mock::LWP::Conditional" : "0",
             "Test::MockObject" : "0",
             "Test::More" : "0"
          }
@@ -52,7 +50,7 @@
       "runtime" : {
          "requires" : {
             "Class::Accessor::Fast" : "0.34",
-            "Data::Dump" : "1.17",
+            "Crypt::OpenSSL::RSA" : "0",
             "JSON::WebToken" : "0.10",
             "JSON::XS" : "0",
             "MIME::Base64" : "3.11",

--- a/cpanfile
+++ b/cpanfile
@@ -1,16 +1,14 @@
 requires 'Class::Accessor::Fast', '0.34';
-requires 'Data::Dump', '1.17';
 requires 'JSON::XS';
 requires 'JSON::WebToken', '0.10';
+requires 'Crypt::OpenSSL::RSA';
 requires 'MIME::Base64', '3.11';
 requires 'OAuth::Lite2', '0.10';
 requires 'Params::Validate', '0.95';
 requires 'perl', '5.008001';
 
 on build => sub {
-    requires 'Crypt::OpenSSL::RSA';
     requires 'ExtUtils::MakeMaker', '6.62';
-    requires 'Test::Mock::LWP::Conditional';
     requires 'Test::More';
     requires 'Test::MockObject';
 };


### PR DESCRIPTION
Remove the unused dependencies `Data::Dump` and `Test::Mock::LWP::Conditional`.
Additionally, move the category `Crypt::OpenSSL::RSA`, which is required for `JSON::WebToken` in runtime.